### PR TITLE
Removed deployment to gh-pages from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,25 +139,6 @@ jobs:
           name: Publish production package
           command: bash scripts/publish_prod.sh
 
-  publish_docs:
-    <<: *defaults
-    steps:
-      - checkout
-      # Download and cache dependencies
-      - restore_cache: *restore-node-modules
-      # Install dependencies
-      - run:
-          name: Install dependencies
-          command: npm install
-      # Save cache settings
-      - save_cache: *save-node-modules
-      - run:
-          name: Publish docs to gh-pages
-          command: |
-            git config --global user.email "iubot@iu.edu"
-            git config --global user.name "iubot"
-            npm run deploy
-
 workflows:
   version: 2
   build-test:
@@ -175,10 +156,5 @@ workflows:
       - publish_production_package:
           requires:
             - test
-          filters: *filter-only-master
-          context: iubot
-      - publish_docs:
-          requires:
-            - publish_production_package
           filters: *filter-only-master
           context: iubot


### PR DESCRIPTION
Deployment to `gh-pages` is simple enough that we removed it from CircleCI in favor of handling manually.