### PR TITLE
Reincorporated publish_docs task into CircleCI build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,7 @@ jobs:
 
       # Save cache settings
       - save_cache: *save-node-modules
-
-      # Download new binding
-      - run:
-          name: Rebuild node-sass
-          command: npm rebuild node-sass
-
+      
       # Build!
       - run:
           name: Build components

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/rivet-collapsible
   docker:
-    - image: circleci/node:7.10
+    - image: circleci/node:latest
 
 jobs:
   build:
@@ -138,6 +138,25 @@ jobs:
       - run:
           name: Publish production package
           command: bash scripts/publish_prod.sh
+
+  publish_docs:
+    <<: *defaults
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache: *restore-node-modules
+      # Install dependencies
+      - run:
+          name: Install dependencies
+          command: npm install
+      # Save cache settings
+      - save_cache: *save-node-modules
+      - run:
+          name: Publish docs to gh-pages
+          command: |
+            git config --global user.email "iubot@iu.edu"
+            git config --global user.name "iubot"
+            npm run deploy
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ aliases:
   # Cache Management
   - &restore-node-modules
     keys:
-      - v1-node-modules-{{ checksum "package.json" }}
+      - v2-node-modules-{{ checksum "package.json" }}
 
   - &save-node-modules
     paths:
       - node_modules
-    key: v1-node-modules-{{ checksum "package.json" }}
+    key: v2-node-modules-{{ checksum "package.json" }}
 
   # Branch Filtering
   - &filter-only-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,14 @@ jobs:
           name: Install dependencies
           command: npm install
 
+      # Download new binding
+      - run:
+          name: Rebuild node-sass
+          command: npm rebuild node-sass
+      
       # Save cache settings
       - save_cache: *save-node-modules
-      
+
       # Build!
       - run:
           name: Build components

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,6 @@ jobs:
       - run:
           name: Install dependencies
           command: npm install
-
-      # Download new binding
-      - run:
-          name: Rebuild node-sass
-          command: npm rebuild node-sass
       
       # Save cache settings
       - save_cache: *save-node-modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,11 @@ jobs:
       # Save cache settings
       - save_cache: *save-node-modules
 
+      # Download new binding
+      - run:
+          name: Rebuild node-sass
+          command: npm rebuild node-sass
+
       # Build!
       - run:
           name: Build components

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,3 +177,8 @@ workflows:
             - test
           filters: *filter-only-master
           context: iubot
+      - publish_docs:
+          requires:
+            - publish_production_package
+          filters: *filter-only-master
+          context: iubot


### PR DESCRIPTION
In this PR:

- Updated docker node image to `latest`
- Cleared cache
- Created new cache with current version of node
- Reincorporated `publish_docs` task to run `npm run deploy`