### PR TITLE
Added flex-shrink: 0 to SVG to prevent icon from shrinking when long titles are used

### DIFF
--- a/src/sass/components/_rvt-collapsible.scss
+++ b/src/sass/components/_rvt-collapsible.scss
@@ -27,6 +27,7 @@
 
     svg {
       margin-right: $xs;
+      flex-shrink: 0;
     }
   }
 


### PR DESCRIPTION
Fixes #39.